### PR TITLE
Handle family owner type in subscription query

### DIFF
--- a/backend/internal/usecase/subscription/query/summary.go
+++ b/backend/internal/usecase/subscription/query/summary.go
@@ -110,6 +110,9 @@ func (h SummaryQueryHandler) classifySubscription(sub subscription.Subscription,
 
 	// If no payer, default to personal
 	if payer == nil {
+		if sub.Owner().Type() == types.FamilyOwnerType {
+			return "family"
+		}
 		return "personal"
 	}
 


### PR DESCRIPTION
Update subscription summary query to properly handle the family owner type. This ensures accurate data is retrieved and processed for related operations.